### PR TITLE
Skip static serving on Vercel

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -49,15 +49,17 @@ function initOnce(): Promise<void> {
       const status = err.status || err.statusCode || 500;
       const message = err.message || "Internal Server Error";
       res.status(status).json({ message });
-      // keep original behavior
-      throw err;
+      console.error(err);
     });
 
     // Dev: Vite middleware after routes; Prod: serve built static
-    if (app.get("env") === "development") {
-      await setupVite(app, server);
-    } else {
-      serveStatic(app);
+    // On Vercel, static files are served by the platform so we skip this step
+    if (process.env.VERCEL !== "1") {
+      if (app.get("env") === "development") {
+        await setupVite(app, server);
+      } else {
+        serveStatic(app);
+      }
     }
 
     // Local dev server ONLY — never listen on Vercel


### PR DESCRIPTION
## Summary
- avoid serving static files from Express when running on Vercel
- prevent error rethrows from crashing the serverless handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1e85c238c83269b22cd57032f6a23