### PR TITLE
Add health check endpoint for server

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,6 +9,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // use storage to perform CRUD operations on the storage interface
   // e.g. storage.insertUser(user) or storage.getUserByUsername(username)
 
+  // Simple health check endpoint to verify the server is running
+  app.get("/api/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
   const httpServer = createServer(app);
 
   return httpServer;


### PR DESCRIPTION
## Summary
- add /api/health route returning status ok

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c1ec89c0ac832694d91c26a25b5844